### PR TITLE
Fix system requirements link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The app launches a window displaying a map.
 
 ## Requirements
 
-See the Runtime SDK's [system requirements](https://developers.arcgis.com/java/latest/guide/system-requirements.htm).
+See the Runtime SDK's [system requirements](https://developers.arcgis.com/java/reference/system-requirements/).
 
 ## Resources
 


### PR DESCRIPTION
In README.md, the system requirements link is broken. This PR fixes it.

### Related issue
- https://devtopia.esri.com/runtime/java/issues/6601